### PR TITLE
adding iam_instance_profile variable per DCOS-44550

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,4 +46,5 @@ module "dcos-public-agent-instances" {
   associate_public_ip_address = "${var.aws_associate_public_ip_address}"
   tags                        = "${var.tags}"
   dcos_instance_os            = "${var.dcos_instance_os}"
+  iam_instance_profile        = "${var.aws_iam_instance_profile}"
 }


### PR DESCRIPTION
Currently we are not passing this variable and it will not be created in the lower instance module even if you specify it. 

https://jira.mesosphere.com/browse/DCOS-44550 